### PR TITLE
Don't have CI clone more than the latest commit

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -24,8 +24,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
*This is a test PR internal to my fork, and it should not be merged.*

GitPython needs more history for its tests. Does gitdb? This finds out.